### PR TITLE
Strip spaces pre comment

### DIFF
--- a/isort/comments.py
+++ b/isort/comments.py
@@ -7,7 +7,7 @@ def parse(line: str) -> Tuple[str, str]:
     """
     comment_start = line.find("#")
     if comment_start != -1:
-        return (line[:comment_start], line[comment_start + 1 :].strip())
+        return (line[:comment_start].strip(), line[comment_start + 1 :].strip())
 
     return (line, "")
 

--- a/tests/unit/test_comments.py
+++ b/tests/unit/test_comments.py
@@ -10,6 +10,12 @@ def test_add_to_line():
     )
 
 
+def test_parse():
+    assert isort.comments.parse("import os  # comment") == ("import os", "comment")
+    assert isort.comments.parse("import os       # comment") == ("import os", "comment")
+    assert isort.comments.parse("import os") == ("import os", "")
+
+
 # These tests were written by the `hypothesis.extra.ghostwriter` module
 # and is provided under the Creative Commons Zero public domain dedication.
 


### PR DESCRIPTION
There appears to be a bug that causes the `# NOQA` comment that isort adds to keep getting more and more indented. This makes comments always two space indented, in line with PEP8.